### PR TITLE
Move comments under variables, to make it visible for VSCode preview

### DIFF
--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -7,11 +7,30 @@ type eventListener<K extends WebsocketEvents> = {
 }
 
 export enum WebsocketEvents {
-    open = 'open',          // Connection is opened or re-opened
-    close = 'close',        // Connection is closed
-    error = 'error',        // An error occurred
-    message = 'message',    // A message was received
-    retry = 'retry'         // A try to re-connect is made
+    /**
+     * Connection is opened or re-opened
+     */
+    open = 'open',
+
+    /**
+     * Connection is closed
+     */
+    close = 'close',
+    
+    /**
+     * An error occurred
+     */
+    error = 'error',
+    
+    /**
+     * A message was received
+     */
+    message = 'message',
+
+    /**
+     * A try to re-connect is made
+     */
+    retry = 'retry'
 }
 
 interface WebsocketEventMap {


### PR DESCRIPTION
Small changes that improve developer experience with this library

Before:
documentations is not visible in IDE
<img width="465" alt="Снимок экрана 2022-10-15 в 14 03 50" src="https://user-images.githubusercontent.com/9128731/195974032-6eeb4560-25b5-4119-aa55-63632513b5e2.png">


After:
documentations is visible in IDE and easy to understand for developers
<img width="487" alt="Снимок экрана 2022-10-15 в 14 03 37" src="https://user-images.githubusercontent.com/9128731/195974028-48aad255-3d7e-4adc-b63d-0a9cedc8d7ae.png">


