### PR TITLE
feature/Allow async events add url mutation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 coverage
 
+.idea

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -4,7 +4,7 @@
 
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "target": "es2015",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
This PR adds two features:
* allow modification url after the websocket is built. ex: `ws.url = 'some_new_url'`
* allow async events handlers: ex:
```
   WebsocketBuilder.onRetry(async (ws, ev) => {
     await someAsynTask();
   })
```

---

The use case needed those is:
We have a secured API that requires a temporary token per socket connection, so what is needed is to get a new token asynchronously then append it to the socket url:
```
   WebsocketBuilder.onRetry(async (ws, ev) => {
     const newToken = await someAsynTask();
     ws.url = `/myUrl?token=${newToken}`;
   })
```