### PR TITLE
release/websocket-ts-2-2-1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,9 @@
 {
   "name": "websocket-ts",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "main": "dist/cjs/src/index.js",
   "types": "dist/cjs/src/index.d.ts",
   "module": "dist/esm/src/index.js",
-  "type": "module",
-  "exports": {
-    "import": "./dist/esm/src/index.js",
-    "require": "./dist/cjs/src/index.js"
-  },
   "license": "MIT",
   "keywords": [
     "websocket",
@@ -27,7 +22,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
-    "lint": "cross-env-shell eslint",
+    "lint": "cross-env-shell eslint './src/{**/*,*}.{js,ts}' './tests/{**/*,*}.{js,ts}'",
     "test": "vitest",
     "test:coverage": "vitest --coverage"
   },


### PR DESCRIPTION
### websocket-ts v2.2.1

A **maintenance release** that includes the following updates and improvements:
- Switched the testing-framework from [Jest](https://www.npmjs.com/package/jest) to [vitest](https://www.npmjs.com/package/vitest)
- Upgraded all development-dependencies to their latest version
- Minor adaptations to unit tests to accommodate the updated dependencies.
- Updated the copyright notice and minor revisions to the `README.md`

#### **Upgraded development dependencies:**

| Package Name                                    | Current Version | Updated Version |
|------------------------------------------------|-----------------|-----------------|
| [TypeScript](https://www.npmjs.com/package/typescript) | 5.2.2           | 5.7.3           |
| [ESLint](https://www.npmjs.com/package/eslint)         | 8.49.0          | 9.20.1          |
| [ws](https://www.npmjs.com/package/ws)                 | 7.0.0           | 8.18.0          |

