### PR TITLE
Remove discontinued Snyk vulnerability badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 <div align="center">
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jjxxs/websocket-ts/gh-pages/websocket-ts-logo-dark.svg" />
-  <img src="https://raw.githubusercontent.com/jjxxs/websocket-ts/gh-pages/websocket-ts-logo.svg" alt="websocket-ts" width="300" height="65" />
-</picture>
+<img src="https://raw.githubusercontent.com/jjxxs/websocket-ts/gh-pages/websocket-ts-logo.svg" alt="websocket-ts" width="300" height="65" />
 </div>
 &nbsp;
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ A <b>WebSocket</b> for browsers with <b>auto-reconnect</b> and <b>message buffer
 
 [![npm version](https://img.shields.io/npm/v/websocket-ts.svg)](https://www.npmjs.org/package/websocket-ts)
 [![Bundle Size](https://deno.bundlejs.com/badge?q=websocket-ts@2.2.1)](https://bundlejs.com/?q=websocket-ts)
-[![Known Vulnerabilities](https://snyk.io/test/npm/websocket-ts/badge.svg)](https://snyk.io/test/npm/websocket-ts)
 [![License](https://img.shields.io/github/license/jjxxs/websocket-ts)](/LICENSE)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 <div align="center">
-<img src="https://raw.githubusercontent.com/jjxxs/websocket-ts/gh-pages/websocket-ts-logo.svg" alt="websocket-ts" width="300" height="65" />
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jjxxs/websocket-ts/gh-pages/websocket-ts-logo-dark.svg" />
+  <img src="https://raw.githubusercontent.com/jjxxs/websocket-ts/gh-pages/websocket-ts-logo.svg" alt="websocket-ts" width="300" height="65" />
+</picture>
 </div>
 &nbsp;
 <div align="center">


### PR DESCRIPTION
The Snyk public npm test endpoint has been permanently shut down (HTTP 410), leaving a broken badge image in the README. This removes it.